### PR TITLE
Bump to HAL 2.2.3.Final

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-console-build</artifactId>
-        <version>1.5.4.Final</version>
+        <version>2.2.3.Final</version>
     </parent>
 
     <!-- the GUI extensions -->

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-console-extension</artifactId>
-        <version>1.5.4.Final</version>
+        <version>2.2.3.Final</version>
     </parent>
 
   <scm>

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/SubsystemView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/SubsystemView.java
@@ -22,7 +22,6 @@ import java.util.EnumSet;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.jboss.as.console.client.shared.dispatch.DispatchAsync;
 import org.jboss.as.console.client.shared.viewframework.AbstractEntityView;
 import org.jboss.as.console.client.shared.viewframework.EntityDetails;
 import org.jboss.as.console.client.shared.viewframework.EntityEditor;
@@ -34,6 +33,7 @@ import org.jboss.as.console.client.teiid.model.SubsystemConfiguration;
 import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
 import org.jboss.ballroom.client.widgets.forms.FormAdapter;
 import org.jboss.ballroom.client.widgets.tables.DefaultCellTable;
+import org.jboss.dmr.client.dispatch.DispatchAsync;
 
 public class SubsystemView extends AbstractEntityView<SubsystemConfiguration> implements SubsystemPresenter.MyView, FrameworkPresenter {
     private final EntityToDmrBridge<SubsystemConfiguration> bridge;

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/TranslatorView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/TranslatorView.java
@@ -21,7 +21,6 @@ package org.jboss.as.console.client.teiid;
 import com.google.gwt.user.cellview.client.TextColumn;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.jboss.as.console.client.shared.dispatch.DispatchAsync;
 import org.jboss.as.console.client.shared.viewframework.AbstractEntityView;
 import org.jboss.as.console.client.shared.viewframework.Columns.NameColumn;
 import org.jboss.as.console.client.shared.viewframework.EntityToDmrBridge;
@@ -32,6 +31,7 @@ import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
 import org.jboss.ballroom.client.widgets.forms.Form;
 import org.jboss.ballroom.client.widgets.forms.FormAdapter;
 import org.jboss.ballroom.client.widgets.tables.DefaultCellTable;
+import org.jboss.dmr.client.dispatch.DispatchAsync;
 
 public class TranslatorView extends AbstractEntityView<Translator> implements TranslatorPresenter.MyView, FrameworkPresenter {
     private final EntityToDmrBridgeImpl<Translator> bridge;

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/TransportView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/TransportView.java
@@ -20,7 +20,6 @@ package org.jboss.as.console.client.teiid;
 
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
-import org.jboss.as.console.client.shared.dispatch.DispatchAsync;
 import org.jboss.as.console.client.shared.viewframework.AbstractEntityView;
 import org.jboss.as.console.client.shared.viewframework.Columns;
 import org.jboss.as.console.client.shared.viewframework.EntityToDmrBridge;
@@ -31,6 +30,7 @@ import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
 import org.jboss.ballroom.client.widgets.forms.Form;
 import org.jboss.ballroom.client.widgets.forms.FormAdapter;
 import org.jboss.ballroom.client.widgets.tables.DefaultCellTable;
+import org.jboss.dmr.client.dispatch.DispatchAsync;
 
 public class TransportView extends AbstractEntityView<Transport> implements TransportPresenter.MyView, FrameworkPresenter {
     private final EntityToDmrBridgeImpl<Transport> bridge;

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/TeiidPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/TeiidPresenter.java
@@ -18,22 +18,7 @@
  */
 package org.jboss.as.console.client.teiid.runtime;
 
-import static org.jboss.dmr.client.ModelDescriptionConstants.ADDRESS;
-import static org.jboss.dmr.client.ModelDescriptionConstants.OP;
-import static org.jboss.dmr.client.ModelDescriptionConstants.RESULT;
-
-import org.jboss.as.console.client.domain.model.SimpleCallback;
-import org.jboss.as.console.client.shared.dispatch.DispatchAsync;
-import org.jboss.as.console.client.shared.dispatch.impl.DMRAction;
-import org.jboss.as.console.client.shared.dispatch.impl.DMRResponse;
-import org.jboss.as.console.client.shared.runtime.RuntimeBaseAddress;
-import org.jboss.as.console.client.shared.state.ServerSelectionChanged;
-import org.jboss.as.console.client.shared.subsys.RevealStrategy;
-import org.jboss.as.console.client.teiid.model.EngineStatistics;
-import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
-import org.jboss.as.console.client.widgets.forms.EntityAdapter;
-import org.jboss.as.console.spi.RuntimeExtension;
-import org.jboss.dmr.client.ModelNode;
+import static org.jboss.dmr.client.ModelDescriptionConstants.*;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.inject.Inject;
@@ -44,6 +29,18 @@ import com.gwtplatform.mvp.client.annotations.NameToken;
 import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.proxy.Place;
 import com.gwtplatform.mvp.client.proxy.Proxy;
+import org.jboss.as.console.client.domain.model.SimpleCallback;
+import org.jboss.as.console.client.shared.runtime.RuntimeBaseAddress;
+import org.jboss.as.console.client.shared.state.ServerSelectionChanged;
+import org.jboss.as.console.client.shared.subsys.RevealStrategy;
+import org.jboss.as.console.client.teiid.model.EngineStatistics;
+import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
+import org.jboss.as.console.client.widgets.forms.EntityAdapter;
+import org.jboss.as.console.spi.RuntimeExtension;
+import org.jboss.dmr.client.ModelNode;
+import org.jboss.dmr.client.dispatch.DispatchAsync;
+import org.jboss.dmr.client.dispatch.impl.DMRAction;
+import org.jboss.dmr.client.dispatch.impl.DMRResponse;
 
 public class TeiidPresenter extends Presenter<TeiidPresenter.MyView, TeiidPresenter.MyProxy> 
 	implements ServerSelectionChanged.ChangeListener {

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/TeiidView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/TeiidView.java
@@ -18,22 +18,21 @@
  */
 package org.jboss.as.console.client.teiid.runtime;
 
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Widget;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.DisposableViewImpl;
+import org.jboss.as.console.client.layout.SimpleLayout;
 import org.jboss.as.console.client.shared.runtime.Metric;
 import org.jboss.as.console.client.shared.runtime.Sampler;
 import org.jboss.as.console.client.shared.runtime.charts.Column;
 import org.jboss.as.console.client.shared.runtime.charts.NumberColumn;
 import org.jboss.as.console.client.shared.runtime.plain.PlainColumnView;
-import org.jboss.as.console.client.shared.viewframework.builder.SimpleLayout;
 import org.jboss.as.console.client.teiid.model.EngineStatistics;
 import org.jboss.ballroom.client.widgets.tools.ToolButton;
 import org.jboss.ballroom.client.widgets.tools.ToolStrip;
-
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.user.client.ui.Widget;
 
 @SuppressWarnings("nls")
 public class TeiidView extends DisposableViewImpl implements TeiidPresenter.MyView {

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBPresenter.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBPresenter.java
@@ -18,19 +18,23 @@
  */
 package org.jboss.as.console.client.teiid.runtime;
 
-import static org.jboss.dmr.client.ModelDescriptionConstants.ADDRESS;
-import static org.jboss.dmr.client.ModelDescriptionConstants.OP;
-import static org.jboss.dmr.client.ModelDescriptionConstants.RESULT;
+import static org.jboss.dmr.client.ModelDescriptionConstants.*;
 
 import java.util.List;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+import com.gwtplatform.mvp.client.Presenter;
+import com.gwtplatform.mvp.client.View;
+import com.gwtplatform.mvp.client.annotations.NameToken;
+import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
+import com.gwtplatform.mvp.client.proxy.Place;
+import com.gwtplatform.mvp.client.proxy.Proxy;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.domain.model.ServerInstance;
 import org.jboss.as.console.client.domain.model.SimpleCallback;
 import org.jboss.as.console.client.shared.BeanFactory;
-import org.jboss.as.console.client.shared.dispatch.DispatchAsync;
-import org.jboss.as.console.client.shared.dispatch.impl.DMRAction;
-import org.jboss.as.console.client.shared.dispatch.impl.DMRResponse;
 import org.jboss.as.console.client.shared.runtime.RuntimeBaseAddress;
 import org.jboss.as.console.client.shared.state.GlobalServerSelection;
 import org.jboss.as.console.client.shared.subsys.RevealStrategy;
@@ -46,16 +50,9 @@ import org.jboss.as.console.client.widgets.forms.ApplicationMetaData;
 import org.jboss.as.console.client.widgets.forms.EntityAdapter;
 import org.jboss.as.console.spi.RuntimeExtension;
 import org.jboss.dmr.client.ModelNode;
-
-import com.google.gwt.core.client.Scheduler;
-import com.google.inject.Inject;
-import com.google.web.bindery.event.shared.EventBus;
-import com.gwtplatform.mvp.client.Presenter;
-import com.gwtplatform.mvp.client.View;
-import com.gwtplatform.mvp.client.annotations.NameToken;
-import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
-import com.gwtplatform.mvp.client.proxy.Place;
-import com.gwtplatform.mvp.client.proxy.Proxy;
+import org.jboss.dmr.client.dispatch.DispatchAsync;
+import org.jboss.dmr.client.dispatch.impl.DMRAction;
+import org.jboss.dmr.client.dispatch.impl.DMRResponse;
 
 @SuppressWarnings("nls")
 public class VDBPresenter extends Presenter<VDBPresenter.MyView, VDBPresenter.MyProxy> implements GlobalServerSelection.ServerSelectionListener {

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBView.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBView.java
@@ -43,7 +43,7 @@ import com.google.gwt.view.client.SelectionChangeEvent;
 import com.google.gwt.view.client.SingleSelectionModel;
 import org.jboss.as.console.client.Console;
 import org.jboss.as.console.client.core.SuspendableViewImpl;
-import org.jboss.as.console.client.shared.viewframework.builder.MultipleToOneLayout;
+import org.jboss.as.console.client.layout.MultipleToOneLayout;
 import org.jboss.as.console.client.teiid.model.CacheStatistics;
 import org.jboss.as.console.client.teiid.model.DataModelFactory;
 import org.jboss.as.console.client.teiid.model.KeyValuePair;

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
         <groupId>org.jboss.teiid</groupId>
         <artifactId>teiid-parent</artifactId>
-        <version>8.4.1</version>    
+        <version>8.6.0.Final</version>
 	</parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Teiid Console :: Parent</name>
@@ -92,5 +92,33 @@
         <module>app</module>
         <module>dist</module>
     </modules>
+    <repositories>
+        <repository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <layout>default</layout>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jboss-public-repository-group</id>
+            <name>JBoss Public Maven Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+            <layout>default</layout>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>
 


### PR DESCRIPTION
Summary of changes:
- Changed version of parent pom to `org.jboss.teiid:teiid-parent:pom:8.6.0.Final` (`org.jboss.teiid:teiid-parent:pom:8.4.1` could not be found?)
- Added JBoss Nexus (plugin) repositories (to fix missing dependencies)
- Bumped to HAL 2.2.3.Final
- Fixed import statements
