### PR TITLE
TEIID-3480: use a procedure on top of both internal status table and …

### DIFF
--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBCachingTab.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBCachingTab.java
@@ -271,7 +271,7 @@ public class VDBCachingTab extends VDBProvider {
 	}
 	
 	private void refresh() {
-		this.presenter.executeQuery(getVdbName(), getVdbVersion(), "select * from sysadmin.matviews", MaterializedView.class.getName());
+		this.presenter.executeQuery(getVdbName(), getVdbVersion(), "EXEC SYSADMIN.matViewsStatus()", MaterializedView.class.getName());
 		this.presenter.getCacheStatistics();
 	}
 	


### PR DESCRIPTION
The procedure `matViewsStatus()` are on top of both internal status table `sysadmin.matviews` and external status table which exist in physical databases, this will solve External Materialization status not show in UI issue 