### PR TITLE
TEIIDWEBCN-25: fix external Materialized Status Tables Reload error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 app/overlays
 gui/target
+gui/bin
 .project
 .classpath
 .settings

--- a/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBCachingTab.java
+++ b/gui/src/main/java/org/jboss/as/console/client/teiid/runtime/VDBCachingTab.java
@@ -247,8 +247,7 @@ public class VDBCachingTab extends VDBProvider {
 	}	
 
 	private void invalidate(MaterializedView view, String queryId) {
-		String viewName = view.getModelName()+"."+view.getTableName();
-		String sql = "CALL SYSADMIN.refreshMatView(viewname=>'"+viewName+"', invalidate=>true)";
+		String sql = "CALL SYSADMIN.loadMatView('" +  view.getModelName() + "', '" + view.getTableName() + "', true)";
 		this.presenter.executeQuery(getVdbName(), getVdbVersion(), sql, queryId);
 	}
 	


### PR DESCRIPTION
Base on changes in [TEIID-4142](https://issues.jboss.org/browse/TEIID-4142), `SYSADMIN.loadMatView` can work for both internal and external Mat View